### PR TITLE
Add Cortex MCP Server

### DIFF
--- a/cortex-mcp.json
+++ b/cortex-mcp.json
@@ -15,7 +15,7 @@
     "type": "environment",
     "variables": ["CORTEX_API_TOKEN"]
   },
-  "transports": ["stdio", "sse"],
+  "transports": ["stdio", "sse", "streamable-http"],
   "tools": [
     "listAllEntities",
     "listEntityDescriptors",

--- a/cortex-mcp.json
+++ b/cortex-mcp.json
@@ -1,4 +1,4 @@
-
+{
   "id": "cortex-mcp",
   "name": "Cortex MCP Server",
   "description": "Cortex’s MCP Server brings real-time engineering context into AI assistants and IDEs. Query service ownership, production readiness, migrations, compliance, and more directly from your Cortex workspace.",
@@ -43,5 +43,3 @@
     }
   ]
 }
-
-Add Cortex MCP Server to registry

--- a/cortex-mcp.json
+++ b/cortex-mcp.json
@@ -13,7 +13,7 @@
   ],
   "auth": {
     "type": "environment",
-    "variables": ["CORTEX_API_TOKEN", "CORTEX_API_BASE_URL"]
+    "variables": ["CORTEX_API_TOKEN"]
   },
   "transports": ["stdio", "sse"],
   "tools": [

--- a/cortex-mcp.json
+++ b/cortex-mcp.json
@@ -1,0 +1,47 @@
+
+  "id": "cortex-mcp",
+  "name": "Cortex MCP Server",
+  "description": "Cortex’s MCP Server brings real-time engineering context into AI assistants and IDEs. Query service ownership, production readiness, migrations, compliance, and more directly from your Cortex workspace.",
+  "repository": "https://github.com/cortexapps/cortex-mcp",
+  "logo": "https://raw.githubusercontent.com/cortexapps/cortex-mcp/main/assets/logo.png",
+  "categories": [
+    "Developer Productivity",
+    "Internal Developer Portal",
+    "Service Ownership",
+    "Compliance",
+    "Engineering Intelligence"
+  ],
+  "auth": {
+    "type": "environment",
+    "variables": ["CORTEX_API_TOKEN", "CORTEX_API_BASE_URL"]
+  },
+  "transports": ["stdio", "sse"],
+  "tools": [
+    "listAllEntities",
+    "listEntityDescriptors",
+    "listDependenciesForEntity",
+    "getDependency",
+    "getEntityDetails",
+    "getCustomDataForEntity",
+    "getCustomDataForEntityByKey",
+    "getCurrentOncallForEntity",
+    "getEntityDescriptor",
+    "listInitiatives",
+    "getInitiative",
+    "listRelationshipTypes",
+    "getRelationshipTypeDetails",
+    "listEntityRelationships",
+    "listScorecards",
+    "getScorecard",
+    "getScorecardNextStepsForEntity",
+    "listScorecardScores"
+  ],
+  "maintainers": [
+    {
+      "name": "Cortex Engineering Team",
+      "email": "support@cortex.io"
+    }
+  ]
+}
+
+Add Cortex MCP Server to registry

--- a/cortex-mcp.json
+++ b/cortex-mcp.json
@@ -39,7 +39,7 @@
   "maintainers": [
     {
       "name": "Cortex Engineering Team",
-      "email": "support@cortex.io"
+      "email": "help@cortex.io"
     }
   ]
 }


### PR DESCRIPTION
Retrieve details on services, teams, Scorecards, and initiatives from Cortex. Query service ownership, review scorecard results, and explore initiatives to understand progress toward standards and organizational goals. Gain system context quickly to improve developer productivity and operational reliability.

<!-- Provide a brief description of your changes -->

Server: cortex-mcp
Changes to: New server addition (tools only, no resources/prompts yet)

## Description

This PR adds Cortex MCP Server to the registry.

Repository: https://github.com/cortexapps/cortex-mcp  
Description: Cortex’s MCP Server brings real-time engineering context into AI assistants and IDEs. Developers can query service ownership, production readiness, migrations, compliance, and more directly from their Cortex workspace.  
Auth: CORTEX_API_TOKEN (required), CORTEX_API_BASE_URL (optional for self-managed)  
Transports: stdio, sse  

Added file: servers/cortex-mcp.json

How Has This Been Tested?
-Tested with Cursor (stdio transport) using mcp.json config.
-Tested with Claude Desktop (SSE transport).
- Verified that tools such as listAllEntities, getEntityDetails, and getScorecard return expected results against a Cortex workspace.

Breaking Changes
- None. This is a new server.

Types of changes

Bug fix (non-breaking change which fixes an issue)
[X] New feature (non-breaking change which adds functionality)
Breaking change (fix or feature that would cause existing functionality to change)
Documentation update

Checklist
[X] I have read the [MCP Protocol Documentation](https://modelcontextprotocol.io/)
[X] My changes follow MCP security best practices
[X] I have updated the server's README accordingly
[X] I have tested this with an LLM client
[X] My code follows the repository's style guidelines
[X] New and existing tests pass locally
[X] I have added appropriate error handling
[X] I have documented all environment variables and configuration options

Additional context
- Cortex MCP server requires a CORTEX_API_TOKEN (with optional CORTEX_API_BASE_URL for self-managed instances).
- Distributed as a Docker image: ghcr.io/cortexapps/cortex-mcp:latest.
- This submission adds cortex-mcp.json under servers/ to make Cortex discoverable via the OSS MCP Community Registry and GitHub’s MCP Registry.
